### PR TITLE
adiciona testes unitários do AuthController

### DIFF
--- a/src/backend/PagaAi.Backend.sln
+++ b/src/backend/PagaAi.Backend.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -16,6 +15,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Usuarios.API", "Usuarios.API\Usuarios.API.csproj", "{D5D802BE-7CAB-402E-B0AD-CCEB9DEBD805}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Clientes.API.Tests", "Clientes.API.Tests\Clientes.API.Tests.csproj", "{072ABEA0-165F-445B-BB4F-1769C0F55B6E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Usuarios.Tests", "Usuarios.Tests\Usuarios.Tests.csproj", "{F2AAE6FB-F4AD-454B-87D6-99FE7F1F1DA3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,5 +55,9 @@ Global
 		{072ABEA0-165F-445B-BB4F-1769C0F55B6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{072ABEA0-165F-445B-BB4F-1769C0F55B6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{072ABEA0-165F-445B-BB4F-1769C0F55B6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2AAE6FB-F4AD-454B-87D6-99FE7F1F1DA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2AAE6FB-F4AD-454B-87D6-99FE7F1F1DA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2AAE6FB-F4AD-454B-87D6-99FE7F1F1DA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2AAE6FB-F4AD-454B-87D6-99FE7F1F1DA3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/backend/Usuarios.Tests/AuthControllerTests.cs
+++ b/src/backend/Usuarios.Tests/AuthControllerTests.cs
@@ -1,0 +1,182 @@
+﻿using Xunit;
+using Moq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using MongoDB.Driver;
+using Usuarios.API.Controllers;
+using UserEntity = Usuario.API.Models.Usuario;
+
+namespace backend.Usuarios.Tests;
+
+public class AuthControllerTests
+{
+    private readonly Mock<IMongoCollection<UserEntity>> _mockCollection;
+    private readonly Mock<IMongoDatabase> _mockDatabase;
+    private readonly Mock<IConfiguration> _mockConfig;
+    private readonly AuthController _controller;
+
+    public AuthControllerTests()
+    {
+        _mockCollection = new Mock<IMongoCollection<UserEntity>>();
+        _mockDatabase = new Mock<IMongoDatabase>();
+        _mockConfig = new Mock<IConfiguration>();
+
+        _mockConfig.Setup(c => c["JwtSettings:SecretKey"])
+            .Returns("chave-super-secreta-teste-2026-minima-32chars!");
+        _mockConfig.Setup(c => c["JwtSettings:Issuer"]).Returns("pagai-api");
+        _mockConfig.Setup(c => c["JwtSettings:Audience"]).Returns("pagai-app");
+
+        _mockDatabase.Setup(d => d.GetCollection<UserEntity>("usuarios", null))
+            .Returns(_mockCollection.Object);
+
+        _controller = new AuthController(_mockDatabase.Object, _mockConfig.Object);
+    }
+
+    [Fact]
+    public async Task Registrar_DeveRetornar201_QuandoEmailNaoExiste()
+    {
+        var novoUsuario = new UserEntity
+        {
+            Nome = "Renata Teste",
+            Email = "renata@teste.com",
+            Senha = "senha123"
+        };
+
+        var mockCursor = CriarCursorVazio();
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<UserEntity>>(),
+            It.IsAny<FindOptions<UserEntity, UserEntity>>(),
+            default))
+            .ReturnsAsync(mockCursor.Object);
+
+        _mockCollection.Setup(c => c.InsertOneAsync(
+            It.IsAny<UserEntity>(), null, default))
+            .Returns(Task.CompletedTask);
+
+        var resultado = await _controller.Registrar(novoUsuario);
+
+        resultado.Should().BeOfType<CreatedResult>();
+    }
+
+    [Fact]
+    public async Task Registrar_DeveRetornar400_QuandoEmailJaExiste()
+    {
+        var usuarioExistente = new UserEntity
+        {
+            Email = "renata@teste.com",
+            Nome = "Renata",
+            Senha = BCrypt.Net.BCrypt.HashPassword("senha123")
+        };
+
+        var mockCursor = CriarCursorComUsuario(usuarioExistente);
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<UserEntity>>(),
+            It.IsAny<FindOptions<UserEntity, UserEntity>>(),
+            default))
+            .ReturnsAsync(mockCursor.Object);
+
+        var resultado = await _controller.Registrar(new UserEntity
+        {
+            Email = "renata@teste.com",
+            Nome = "Outro",
+            Senha = "outrasenha"
+        });
+
+        resultado.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Login_DeveRetornarToken_QuandoCredenciaisCorretas()
+    {
+        var senhaHash = BCrypt.Net.BCrypt.HashPassword("senha123");
+        var usuario = new UserEntity
+        {
+            Id = "507f1f77bcf86cd799439011",
+            Nome = "Renata",
+            Email = "renata@teste.com",
+            Senha = senhaHash
+        };
+
+        var mockCursor = CriarCursorComUsuario(usuario);
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<UserEntity>>(),
+            It.IsAny<FindOptions<UserEntity, UserEntity>>(),
+            default))
+            .ReturnsAsync(mockCursor.Object);
+
+        var resultado = await _controller.Login(new LoginRequest
+        {
+            Email = "renata@teste.com",
+            Senha = "senha123"
+        });
+
+        resultado.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task Login_DeveRetornar401_QuandoSenhaErrada()
+    {
+        var usuario = new UserEntity
+        {
+            Email = "renata@teste.com",
+            Senha = BCrypt.Net.BCrypt.HashPassword("senha123")
+        };
+
+        var mockCursor = CriarCursorComUsuario(usuario);
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<UserEntity>>(),
+            It.IsAny<FindOptions<UserEntity, UserEntity>>(),
+            default))
+            .ReturnsAsync(mockCursor.Object);
+
+        var resultado = await _controller.Login(new LoginRequest
+        {
+            Email = "renata@teste.com",
+            Senha = "senhaerrada"
+        });
+
+        resultado.Should().BeOfType<UnauthorizedObjectResult>();
+    }
+
+    [Fact]
+    public async Task Login_DeveRetornar401_QuandoUsuarioNaoExiste()
+    {
+        var mockCursor = CriarCursorVazio();
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<UserEntity>>(),
+            It.IsAny<FindOptions<UserEntity, UserEntity>>(),
+            default))
+            .ReturnsAsync(mockCursor.Object);
+
+        var resultado = await _controller.Login(new LoginRequest
+        {
+            Email = "naoexiste@teste.com",
+            Senha = "qualquer"
+        });
+
+        resultado.Should().BeOfType<UnauthorizedObjectResult>();
+    }
+
+    private Mock<IAsyncCursor<UserEntity>> CriarCursorVazio()
+    {
+        var cursor = new Mock<IAsyncCursor<UserEntity>>();
+        cursor.SetupSequence(c => c.MoveNextAsync(default))
+            .ReturnsAsync(false);
+        cursor.Setup(c => c.Current)
+            .Returns(new List<UserEntity>());
+        return cursor;
+    }
+
+    private Mock<IAsyncCursor<UserEntity>> CriarCursorComUsuario(UserEntity usuario)
+    {
+        var cursor = new Mock<IAsyncCursor<UserEntity>>();
+        cursor.SetupSequence(c => c.MoveNextAsync(default))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+        cursor.Setup(c => c.Current)
+            .Returns(new List<UserEntity> { usuario });
+        return cursor;
+    }
+}
+

--- a/src/backend/Usuarios.Tests/Usuarios.Tests.csproj
+++ b/src/backend/Usuarios.Tests/Usuarios.Tests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Usuarios.API\Usuarios.API.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
O que foi feito

Projeto Criado Usuarios.Testes com testes unitários do AuthController
5 testes cobrindo os cenários de registrador e login
Testes ó

Registrador_DeveRetornar201_QuandoEmailNaoExiste
Registrador_DeveRetornar400_QuandoEmailJaExiste
Login_DeveRetornarToken_QuandoCredenciaisCorretas
Login_DeveRetornar401_QuandoSenhaErrada
Login_DeveRetornar401_QuandoUsuarioNaoExiste
Resultado
Total: 5 | Aprovados: 5 | Falhou: 0